### PR TITLE
(SIMP-6106) Add deferred_resources::files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 * Mon Apr 01 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.2.0
-- Add deferred_resources::users and deferred_resources::groups
+- Add deferred_resources::users
+- Add deferred_resources::groups
+- Add deferred_resources::files
+- Add 'override_existing_attributes' capability to the 'deferred_resources'
+  native type
 - Drop Puppet 4 support
 - Add Puppet 6 support
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,13 +6,14 @@
 **Classes**
 
 * [`deferred_resources`](#deferred_resources): 
-* [`deferred_resources::groups`](#deferred_resourcesgroups): This class takes two `Hashes` of group resources, one to remove, and one to install.  After the entire puppet catalog has been compiled, it w
+* [`deferred_resources::files`](#deferred_resourcesfiles): This class takes an Array of file resources to remove, and a Hash of file resources to install.  After the entire puppet catalog has been com
+* [`deferred_resources::groups`](#deferred_resourcesgroups): This class takes an Array of group resources to remove, and a Hash of group resources to install.  After the entire puppet catalog has been c
 * [`deferred_resources::packages`](#deferred_resourcespackages): This class takes two `Hashes` of packages, one to remove and one to install.  After the entire puppet catalog has been compiled, it will proc
-* [`deferred_resources::users`](#deferred_resourcesusers): This class takes two `Hashes` of user resources, one to remove, and one to install.  After the entire puppet catalog has been compiled, it wi
+* [`deferred_resources::users`](#deferred_resourcesusers): This class takes an Array of user resources to remove, and a Hash of user resources to install.  After the entire puppet catalog has been com
 
 **Resource types**
 
-* [`deferred_resources`](#deferred_resources): WARNING: This type is **NOT** meant to be called directly. Please use the helper classes in the module.  This type will process after the cat
+* [`deferred_resources`](#deferred_resources): *** DANGER ***  THIS RESOURCE TYPE DOES THINGS THAT MAY BE CONFUSING MAKE SURE YOU FULLY UNDERSTAND HOW IT WORKS PRIOR TO USING IT  *** DANGE
 
 ## Classes
 
@@ -50,10 +51,79 @@ Data type: `Boolean`
 
 Default value: `true`
 
+### deferred_resources::files
+
+This class takes an Array of file resources to remove, and a Hash of file
+resources to install.
+
+After the entire puppet catalog has been compiled, it will process both lists
+and, for any resource that is not already defined in the catalog, it will
+take the appropriate action.
+
+An exception will be raised if you list the same file in both lists.
+
+#### Parameters
+
+The following parameters are available in the `deferred_resources::files` class.
+
+##### `remove`
+
+Data type: `Array[Stdlib::Absolutepath]`
+
+A list of files to remove.
+
+Default value: []
+
+##### `install`
+
+Data type: `Hash[Stdlib::Absolutepath, Hash]`
+
+A Hash of files to install.
+
+Default value: {}
+
+##### `update_existing_resources`
+
+Data type: `Boolean`
+
+**DANGEROUS** - READ CAREFULLY
+
+Update the following attributes of resources that already exist in the
+catalog if set in the `install` Hash:
+
+  * user
+  * group
+  * content
+    * Will unset `source`
+
+If you wish to affect additional parameters on an existing resource in the
+catalog, you should not use this class and should instead use a Resource
+Collector.
+
+@see https://puppet.com/docs/puppet/5.3/lang_resources_advanced.html#amending-attributes-with-a-collector
+
+Default value: `false`
+
+##### `mode`
+
+Data type: `Enum['warning','enforcing']`
+
+@see `deferred_resources::mode`
+
+Default value: $deferred_resources::mode
+
+##### `log_level`
+
+Data type: `Simplib::PuppetLogLevel`
+
+@see `deferred_resources::log_level`
+
+Default value: $deferred_resources::log_level
+
 ### deferred_resources::groups
 
-This class takes two `Hashes` of group resources, one to remove, and one to
-install.
+This class takes an Array of group resources to remove, and a Hash of group
+resources to install.
 
 After the entire puppet catalog has been compiled, it will process both lists
 and, for any resource that is not already defined in the catalog, it will
@@ -67,7 +137,7 @@ The following parameters are available in the `deferred_resources::groups` class
 
 ##### `remove`
 
-Data type: `Variant[Array[String[1]]]`
+Data type: `Array[String[1]]`
 
 A list of groups to remove.
 
@@ -178,8 +248,8 @@ Default value: $deferred_resources::log_level
 
 ### deferred_resources::users
 
-This class takes two `Hashes` of user resources, one to remove, and one to
-install.
+This class takes an Array of user resources to remove, and a Hash of user
+resources to install.
 
 After the entire puppet catalog has been compiled, it will process both lists
 and, for any resource that is not already defined in the catalog, it will
@@ -193,7 +263,7 @@ The following parameters are available in the `deferred_resources::users` class.
 
 ##### `remove`
 
-Data type: `Variant[Array[String[1]]]`
+Data type: `Array[String[1]]`
 
 A list of users to remove.
 
@@ -230,6 +300,13 @@ Default value: $deferred_resources::log_level
 ## Resource types
 
 ### deferred_resources
+
+*** DANGER ***
+
+THIS RESOURCE TYPE DOES THINGS THAT MAY BE CONFUSING MAKE SURE YOU FULLY
+UNDERSTAND HOW IT WORKS PRIOR TO USING IT
+
+*** DANGER ***
 
 WARNING: This type is **NOT** meant to be called directly. Please use the
 helper classes in the module.
@@ -268,6 +345,25 @@ The type of Puppet resource that will be passed in :resources
 ##### `resources`
 
 A Hash or Array of resources to add to the catalog.
+
+##### `override_existing_attributes`
+
+A Hash or Array of items that should be updated on existing attributes if
+they exist.
+
+ This is basically a controlled resource collector and absolutely must not
+ be taken lightly when used since it will affect existing resources in
+ your catalog.
+
+ If you want to be explicit, use a Resource Collector and do not set this.
+
+ If a Hash is passed, each key is the attribute that can be overridden and
+ an optional hash of options can be passed with the following meanings.
+
+   * 'invalidates':
+     * An Array of entries that this particular parameter invalidates.
+       This means that the items in the lisst will be set to `nil` in the
+       overridden resource.
 
 ##### `log_level`
 

--- a/lib/puppet/type/deferred_resources.rb
+++ b/lib/puppet/type/deferred_resources.rb
@@ -100,7 +100,7 @@ Puppet::Type.newtype(:deferred_resources) do
 
         * 'invalidates':
           * An Array of entries that this particular parameter invalidates.
-            This means that the items in the lisst will be set to `nil` in the
+            This means that the items in the list will be set to `nil` in the
             overridden resource.
     EOM
 

--- a/lib/puppet/type/deferred_resources.rb
+++ b/lib/puppet/type/deferred_resources.rb
@@ -196,21 +196,21 @@ Puppet::Type.newtype(:deferred_resources) do
             # Update the targeted list of attributes if they are present and
             # honor whatever options are passed
             self[:override_existing_attributes].each_pair do |attr, existing_resource_opts|
-              if existing_resource_opts['invalidates']
-                Array(existing_resource_opts['invalidates']).each do |to_invalidate|
-                  to_invalidate = to_invalidate.to_sym
+              if opts[attr.to_sym]
+                if existing_resource_opts['invalidates']
+                  Array(existing_resource_opts['invalidates']).each do |to_invalidate|
+                    to_invalidate = to_invalidate.to_sym
 
-                  Puppet.debug("deferred_resources: Invalidating attribute '#{to_invalidate}' on existing resource #{resource_log_name}")
+                    Puppet.debug("deferred_resources: Invalidating attribute '#{to_invalidate}' on existing resource #{resource_log_name}")
 
-                  if existing_resource.parameters.keys.include?(to_invalidate)
-                    existing_resource.delete(to_invalidate)
+                    if existing_resource.parameters.keys.include?(to_invalidate)
+                      existing_resource.delete(to_invalidate)
+                    end
                   end
                 end
-              end
 
-              Puppet.debug("deferred_resources: Setting value of '#{attr}' to '#{opts[attr]}' on existing resource #{resource_log_name}")
+                Puppet.debug("deferred_resources: Setting value of '#{attr}' to '#{opts[attr]}' on existing resource #{resource_log_name}")
 
-              if opts[attr.to_sym]
                 existing_resource[attr] = opts[attr.to_sym]
               end
             end

--- a/lib/puppet/type/deferred_resources.rb
+++ b/lib/puppet/type/deferred_resources.rb
@@ -127,17 +127,15 @@ Puppet::Type.newtype(:deferred_resources) do
 
       if value.is_a?(Hash)
         value.each_pair do |attr, opts|
-          if attr
-            if attr.is_a?(Hash)
-              invalid_control_opts = (attr.keys - valid_control_opts)
+          if opts && opts.is_a?(Hash)
+            invalid_control_opts = (opts.keys - valid_control_opts)
 
-              unless invalid_control_opts.empty?
-                raise Puppet::Error, %{Unknown control options '#{invalid_control_opts.join("', '")}' passed in the :override_existing_attributes Hash}
-              end
+            unless invalid_control_opts.empty?
+              raise Puppet::Error, %{Unknown control options '#{invalid_control_opts.join("', '")}' passed in the :override_existing_attributes Hash}
+            end
 
-              unless value['invalidates'].is_a?(Array)
-                raise Puppet::Error, "You must pass a list of attributes to override for '#{k}' in the :override_existing_attributes Hash"
-              end
+            unless opts['invalidates'].is_a?(Array)
+              raise Puppet::Error, "You must pass an Array of attributes to override for '#{attr}' in the :override_existing_attributes Hash"
             end
           end
         end

--- a/lib/puppet/type/deferred_resources.rb
+++ b/lib/puppet/type/deferred_resources.rb
@@ -1,5 +1,12 @@
 Puppet::Type.newtype(:deferred_resources) do
   @doc = <<-EOM
+      *** DANGER ***
+
+      THIS RESOURCE TYPE DOES THINGS THAT MAY BE CONFUSING MAKE SURE YOU FULLY
+      UNDERSTAND HOW IT WORKS PRIOR TO USING IT
+
+      *** DANGER ***
+
       WARNING: This type is **NOT** meant to be called directly. Please use the
       helper classes in the module.
 
@@ -30,7 +37,7 @@ Puppet::Type.newtype(:deferred_resources) do
 
     validate do |value|
       unless   value.is_a?(Hash)
-        raise 'Expecting a Hash for :default_options'
+        raise Puppet::Error, 'Expecting a Hash for :default_options'
       end
     end
   end
@@ -72,7 +79,68 @@ Puppet::Type.newtype(:deferred_resources) do
 
     validate do |value|
       unless  value.is_a?(Hash) || value.is_a?(Array)
-        raise 'Expecting a Hash or Array for :resources'
+        raise Puppet::Error, 'Expecting a Hash or Array for :resources'
+      end
+    end
+  end
+
+  newparam(:override_existing_attributes) do
+    desc <<-EOM
+     A Hash or Array of items that should be updated on existing attributes if
+     they exist.
+
+      This is basically a controlled resource collector and absolutely must not
+      be taken lightly when used since it will affect existing resources in
+      your catalog.
+
+      If you want to be explicit, use a Resource Collector and do not set this.
+
+      If a Hash is passed, each key is the attribute that can be overridden and
+      an optional hash of options can be passed with the following meanings.
+
+        * 'invalidates':
+          * An Array of entries that this particular parameter invalidates.
+            This means that the items in the lisst will be set to `nil` in the
+            overridden resource.
+    EOM
+
+    munge do |value|
+      if value.is_a?(Array)
+        value = Hash[value.map{|x| [x, {}]}]
+      end
+
+      value.keys.each do |k|
+        value[k] = {} if value[k].nil?
+      end
+
+      value
+    end
+
+    validate do |value|
+      unless (value.is_a?(Hash) || value.is_a?(Array)) && !value.empty?
+        raise Puppet::Error, 'Expecting an Array or Hash with contents for :override_existing_attributes'
+      end
+
+      valid_control_opts = [
+        'invalidates'
+      ]
+
+      if value.is_a?(Hash)
+        value.each_pair do |attr, opts|
+          if attr
+            if attr.is_a?(Hash)
+              invalid_control_opts = (attr.keys - valid_control_opts)
+
+              unless invalid_control_opts.empty?
+                raise Puppet::Error, %{Unknown control options '#{invalid_control_opts.join("', '")}' passed in the :override_existing_attributes Hash}
+              end
+
+              unless value['invalidates'].is_a?(Array)
+                raise Puppet::Error, "You must pass a list of attributes to override for '#{k}' in the :override_existing_attributes Hash"
+              end
+            end
+          end
+        end
       end
     end
   end
@@ -112,18 +180,48 @@ Puppet::Type.newtype(:deferred_resources) do
     # Go through the provided resources, check if a resource exists.
     # Create the resource or print message as appropriate
     self[:resources].each do |rname, opts|
-      # Symbolize the keys after merging for comparison later
+      # Symbolize the keys after merging for direct comparison later
       opts = self[:default_options].merge(opts).inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
 
+      # Get the easily searchable name
       resource_type = self[:resource_type].to_s.capitalize
+
+      # Directly pull the existing resource if it exists
       existing_resource = catalog.resource(resource_type, rname)
 
+      # A user-friendly name for the resource to add to the logs
       resource_log_name = "#{resource_type}[#{rname}]"
 
       if existing_resource
-        # If the options are different we need to let the user know since that
-        # is a potential policy violation.
-        if (Array(opts) - Array(existing_resource.to_hash)).empty?
+        if self[:override_existing_attributes]
+          if self[:mode] == :enforcing
+            # Update the targeted list of attributes if they are present and
+            # honor whatever options are passed
+            self[:override_existing_attributes].each_pair do |attr, existing_resource_opts|
+              if existing_resource_opts['invalidates']
+                Array(existing_resource_opts['invalidates']).each do |to_invalidate|
+                  to_invalidate = to_invalidate.to_sym
+
+                  Puppet.debug("deferred_resources: Invalidating attribute '#{to_invalidate}' on existing resource #{resource_log_name}")
+
+                  if existing_resource.parameters.keys.include?(to_invalidate)
+                    existing_resource.delete(to_invalidate)
+                  end
+                end
+              end
+
+              Puppet.debug("deferred_resources: Setting value of '#{attr}' to '#{opts[attr]}' on existing resource #{resource_log_name}")
+
+              if opts[attr.to_sym]
+                existing_resource[attr] = opts[attr.to_sym]
+              end
+            end
+          else
+            Puppet.send(self[:log_level], %{deferred_resources: Would have overridden attributes '#{self[:override_existing_attributes].keys.join("', '")}' on existing resource #{resource_log_name}})
+          end
+        elsif (Array(opts) - Array(existing_resource.to_hash)).empty?
+          # If the options are different we need to let the user know since
+          # that is a potential policy violation.
           Puppet.debug("deferred_resources: Ignoring existing resource #{resource_log_name}")
         else
           Puppet.send(self[:log_level], "deferred_resources: Existing resource '#{resource_log_name}' at '#{existing_resource.file}:#{existing_resource.line}' has options that differ from deferred_resources::<x> parameters")

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -1,0 +1,82 @@
+# This class takes an Array of file resources to remove, and a Hash of file
+# resources to install.
+#
+# After the entire puppet catalog has been compiled, it will process both lists
+# and, for any resource that is not already defined in the catalog, it will
+# take the appropriate action.
+#
+# An exception will be raised if you list the same file in both lists.
+#
+# @param remove
+#   A list of files to remove.
+#
+# @param install
+#   A Hash of files to install.
+#
+# @param update_existing_resources
+#   **DANGEROUS** - READ CAREFULLY
+#
+#   Update the following attributes of resources that already exist in the
+#   catalog if set in the `install` Hash:
+#
+#     * user
+#     * group
+#     * content
+#       * Will unset `source`
+#
+#   If you wish to affect additional parameters on an existing resource in the
+#   catalog, you should not use this class and should instead use a Resource
+#   Collector.
+#
+#   @see https://puppet.com/docs/puppet/5.3/lang_resources_advanced.html#amending-attributes-with-a-collector
+#
+# @param mode
+#   @see `deferred_resources::mode`
+#
+# @param log_level
+#   @see `deferred_resources::log_level`
+#
+class deferred_resources::files (
+  Array[Stdlib::Absolutepath]      $remove                    = [],
+  Hash[Stdlib::Absolutepath, Hash] $install                   = {},
+  Boolean                          $update_existing_resources = false,
+  Enum['warning','enforcing']      $mode                      = $deferred_resources::mode,
+  Simplib::PuppetLogLevel          $log_level                 = $deferred_resources::log_level
+
+) inherits deferred_resources {
+
+  if $update_existing_resources {
+    $_override_existing_attributes = {
+      'owner'   => undef,
+      'group'   => undef,
+      'mode'    => undef,
+      'content' => {
+        'invalidates' => ['source']
+      }
+    }
+  }
+  else {
+    $_override_existing_attributes = undef
+  }
+
+  unless empty($remove) {
+    deferred_resources{ "${module_name} File remove":
+      resources                    => $remove,
+      resource_type                => 'file',
+      default_options              => { 'ensure' => 'absent' },
+      mode                         => $mode,
+      log_level                    => $log_level
+    }
+  }
+
+  unless empty($install) {
+    deferred_resources{ "${module_name} File install":
+      resources                    => $install,
+      resource_type                => 'file',
+      default_options              => { 'ensure' => 'present' },
+      override_existing_attributes => $_override_existing_attributes,
+      mode                         => $mode,
+      log_level                    => $log_level
+    }
+  }
+}

--- a/manifests/groups.pp
+++ b/manifests/groups.pp
@@ -24,7 +24,7 @@
 #   @see `deferred_resources::log_level`
 #
 class deferred_resources::groups (
-  Variant[Array[String[1]]]       $remove    = [],
+  Array[String[1]]                $remove    = [],
   Variant[Hash, Array[String[1]]] $install   = {},
   Enum['warning','enforcing']     $mode      = $deferred_resources::mode,
   Simplib::PuppetLogLevel         $log_level = $deferred_resources::log_level

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,5 +29,6 @@ class deferred_resources (
     include 'deferred_resources::packages'
     include 'deferred_resources::users'
     include 'deferred_resources::groups'
+    include 'deferred_resources::files'
   }
 }

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -24,7 +24,7 @@
 #   @see `deferred_resources::log_level`
 #
 class deferred_resources::users (
-  Variant[Array[String[1]]]       $remove    = [],
+  Array[String[1]]                $remove    = [],
   Variant[Hash, Array[String[1]]] $install   = {},
   Enum['warning','enforcing']     $mode      = $deferred_resources::mode,
   Simplib::PuppetLogLevel         $log_level = $deferred_resources::log_level

--- a/spec/acceptance/suites/default/10_files_spec.rb
+++ b/spec/acceptance/suites/default/10_files_spec.rb
@@ -1,0 +1,224 @@
+require 'spec_helper_acceptance'
+
+test_name 'deferred file resources'
+
+describe 'deferred file resources' do
+  let(:manifest) {
+    <<-EOS
+      file { '/tmp/rm_file2': ensure => 'file', content => 'Test RM' }
+      file { '/tmp/add_file1': ensure => 'absent' }
+      file { '/tmp/add_file3': ensure => 'file', content => 'Test Add', mode => '0600' }
+
+      include 'deferred_resources'
+    EOS
+  }
+  let(:hieradata) {
+    <<-EOD
+---
+deferred_resources::files::remove:
+  - '/tmp/rm_file1'
+  - '/tmp/rm_file2'
+deferred_resources::files::install:
+  '/tmp/add_file1':
+    'mode': '0777'
+  '/tmp/add_file2':
+    'mode': '0600'
+    EOD
+  }
+
+  let(:hieradata_enforce) {
+    <<-EOM
+deferred_resources::mode: 'enforcing'
+deferred_resources::log_level: 'debug'
+    EOM
+  }
+
+  # This is meant to be slapped onto the bottom of 'hieradata'
+  let(:hieradata_resource_override) {
+    <<-EOM
+  '/tmp/add_file3':
+    'mode': '0644'
+    'content': 'Changed'
+deferred_resources::mode: 'enforcing'
+deferred_resources::log_level: 'debug'
+deferred_resources::files::update_existing_resources: true
+    EOM
+  }
+
+  hosts.each do |host|
+    context "on #{host}" do
+      def has_file?(host, file)
+        res_info = YAML.safe_load(on(host, %(puppet resource file #{file} --to_yaml)).output)
+
+        if res_info
+          if res_info['file']
+            if res_info['file'][file]
+              return res_info['file'][file]['ensure'] == 'file'
+            end
+          end
+        end
+
+        return false
+      end
+
+      context 'with default parameters' do
+        it 'should work with no errors' do
+          apply_manifest_on(host, manifest, :catch_failures => true)
+        end
+
+        it 'should be idempotent' do
+          apply_manifest_on(host, manifest, :catch_changes => true)
+        end
+
+        it 'should have correct files installed' do
+          # file with ensure absent
+          ['/tmp/add_file1'].each do |file|
+              expect(has_file?(host, file)).to eq false
+          end
+
+          # previously installed file with ensure present
+          ['/tmp/rm_file2'].each do |file|
+              expect(has_file?(host, file)).to eq true
+          end
+        end
+      end
+
+      context "with 'warning' mode and files to ensure removed/installed" do
+        it 'should create a file to be removed' do
+          on(host, 'touch /tmp/rm_file1')
+        end
+
+        it 'should set up hieradata' do
+          set_hieradata_on(host, hieradata)
+        end
+
+        it 'should output messages but not update files' do
+          result = apply_manifest_on(host, manifest, :accept_all_exit_codes => true)
+
+          # files ignored by deferred_resources because they are already in the catalogue
+          ['/tmp/rm_file2','/tmp/add_file1'].each do |file|
+            expect(result.stdout).to match(/Existing resource 'File\[#{file}\]' .+ has options that differ/m)
+          end
+
+          # files that are only in deferred_resources::files::remove
+          ['/tmp/rm_file1'].each do |file|
+             expect(result.stdout).to match(/Would have created File\[#{file}\] with .*:ensure=>"absent"/m)
+          end
+
+          # files that are only in deferred_resources::files::install
+          ['/tmp/add_file2'].each do |file|
+             expect(result.stdout).to match(/Would have created File\[#{file}\] with.*:ensure=>"present"/m)
+          end
+        end
+
+        it 'should not have changed the files installed' do
+          # file removed by another catalogue resource
+          ['/tmp/add_file1'].each do |file|
+              expect(has_file?(host, file)).to eq false
+          end
+
+          # 1 file that would have been removed by deferred_resources and
+          # 1 file installed by another catalog resource
+          ['/tmp/rm_file1','/tmp/rm_file2'].each do |file|
+              expect(has_file?(host, file)).to eq true
+          end
+        end
+      end
+
+      context "with 'enforce' mode, 'debug' log_level, and files to ensure removed/installed" do
+        it 'should create a file to be removed' do
+          on(host, 'touch /tmp/rm_file1')
+        end
+
+        it 'should set up hieradata' do
+          set_hieradata_on(host, hieradata + hieradata_enforce )
+        end
+
+        it 'should not output messages when the manifest it applied' do
+          result = apply_manifest_on(host, manifest, :accept_all_exit_codes => true)
+
+          # files ignored by deferred_resources because they are already in the catalogue
+          ['/tmp/rm_file2','/tmp/add_file1'].each do |file|
+            expect(result.stdout).not_to match(/Existing resource 'File\[#{file}\]' .+ has options that differ/m)
+          end
+
+          # files that are only in deferred_resources::files::remove or
+          # deferred_resources::files::install
+          ['/tmp/rm_file1', '/tmp/add_file2'].each do |file|
+             expect(result.stdout).not_to match(/Would have created File\[#{file}\]/m)
+          end
+        end
+
+        it 'should have removed and installed files' do
+          # 1st file removed by another catalog resource and 1 remaining files
+          # removed by deferred_resources
+          ['/tmp/add_file1', '/tmp/rm_file1'].each do |file|
+              expect(has_file?(host, file)).to eq false
+          end
+
+          # 1st file installed by another catalog resource and 1 remaining files
+          # added by deferred_resources
+          ['/tmp/rm_file2', '/tmp/add_file2'].each do |file|
+              expect(has_file?(host, file)).to eq true
+          end
+        end
+
+        it 'should not have overridden file attributes' do
+          file_attrs = YAML.load(
+            on(host, 'puppet resource file /tmp/add_file2 --to_yaml').output.strip
+          )['file']['/tmp/add_file2']
+
+          expect(file_attrs['mode']).to eq('0600')
+        end
+      end
+
+      context 'overriding exsiting resources' do
+        it 'should set up a clean state' do
+          set_hieradata_on(host, hieradata)
+        end
+
+        it 'should work with no errors' do
+          apply_manifest_on(host, manifest, :catch_failures => true)
+        end
+
+        it 'should set up override hieradata' do
+          set_hieradata_on(host, hieradata + hieradata_resource_override)
+        end
+
+        it 'should override selected parameters' do
+          orig_file_attrs = YAML.load(
+            on(host, 'puppet resource file /tmp/add_file3 --to_yaml').output.strip
+          )['file']['/tmp/add_file3']
+
+          apply_manifest_on(host, manifest, :catch_failures => true)
+
+          new_file_attrs = YAML.load(
+            on(host, 'puppet resource file /tmp/add_file3 --to_yaml').output.strip
+          )['file']['/tmp/add_file3']
+
+          # Remove things that will have changed
+          ['mtime','ctime'].each do |attr|
+            orig_file_attrs.delete(attr)
+            new_file_attrs.delete(attr)
+          end
+
+          expect(new_file_attrs['mode']).to eq('0644')
+          expect(new_file_attrs['content']).to_not eq(orig_file_attrs['content'])
+
+          # Remove the things we know changed
+          ['mode','content'].each do |attr|
+            orig_file_attrs.delete(attr)
+            new_file_attrs.delete(attr)
+          end
+
+          # Nothing else should have changed
+          expect(orig_file_attrs).to eq(new_file_attrs)
+        end
+
+        it 'should be idempotent' do
+          apply_manifest_on(host, manifest, :catch_changes => true)
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/files_spec.rb
+++ b/spec/classes/files_spec.rb
@@ -1,38 +1,40 @@
 require 'spec_helper'
 
-user_array = [
-  'user1',
-  'user2'
+file_array = [
+  '/tmp/file1',
+  '/tmp/file2'
 ]
 
-user_hash = {
-  'user3' => {}
+file_hash = {
+  '/tmp/file3' => {
+    'owner' => 'bob'
+  }
 }
 
-describe 'deferred_resources::users' do
+describe 'deferred_resources::files' do
   shared_examples_for "a structured module" do
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to create_class('deferred_resources') }
   end
 
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts
+          os_facts
         end
 
         context "deferred_resources class without any parameters" do
           let(:params) {{ }}
           it_behaves_like "a structured module"
-          it { is_expected.to_not contain_deferred_resources('deferred_resources User remove')}
-          it { is_expected.to_not contain_deferred_resources('deferred_resources User install')}
+          it { is_expected.to_not contain_deferred_resources('deferred_resources File remove')}
+          it { is_expected.to_not contain_deferred_resources('deferred_resources File install')}
         end
 
         context "with parameters set" do
           let(:params) {{
-            'remove'    => user_array,
-            'install'   => user_hash,
+            'remove'    => file_array,
+            'install'   => file_hash,
             'mode'      => 'enforcing',
             'log_level' => 'debug'
           }}
@@ -47,16 +49,16 @@ describe 'deferred_resources::users' do
 
           it { is_expected.to compile.with_all_deps }
 
-          it { is_expected.to contain_deferred_resources('deferred_resources User remove').with({
-            'resource_type'   => 'user',
+          it { is_expected.to contain_deferred_resources('deferred_resources File remove').with({
+            'resource_type'   => 'file',
             'resources'       => params['remove'],
             'mode'            => params['mode'],
             'default_options' => { 'ensure' => 'absent' },
             'log_level'       => params['log_level']
           })}
 
-          it { is_expected.to contain_deferred_resources('deferred_resources User install').with({
-            'resource_type'   => 'user',
+          it { is_expected.to contain_deferred_resources('deferred_resources File install').with({
+            'resource_type'   => 'file',
             'resources'       => install_hash,
             'mode'            => params['mode'],
             'default_options' => { 'ensure' => 'present' },

--- a/spec/classes/groups_spec.rb
+++ b/spec/classes/groups_spec.rb
@@ -13,7 +13,6 @@ describe 'deferred_resources::groups' do
   shared_examples_for "a structured module" do
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to create_class('deferred_resources') }
-    it { is_expected.to contain_class('deferred_resources') }
   end
 
   context 'supported operating systems' do

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -14,7 +14,6 @@ describe 'deferred_resources::packages' do
   shared_examples_for "a structured module" do
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to create_class('deferred_resources') }
-    it { is_expected.to contain_class('deferred_resources') }
   end
 
   context 'supported operating systems' do

--- a/spec/unit/puppet/type/deferred_resources_spec.rb
+++ b/spec/unit/puppet/type/deferred_resources_spec.rb
@@ -278,6 +278,50 @@ describe deferred_resources_type do
           expect(result[:mode]).to eq('644')
           expect(result[:source]).to be_nil
         end
+
+        it 'should fail on an invalid override option' do
+          expect {
+            deferred_resources_type.new(
+              :name                         => 'foo',
+              :resource_type                => 'file',
+              :mode                         => 'enforcing',
+              :override_existing_attributes => {
+                'owner'   => nil,
+                'group'   => nil,
+                'content' => {
+                  'watermelons' => ['cheese']
+                }
+              },
+              :resources                    => {
+                '/tmp/test' => {
+                  'mode' => '0777'
+                }
+              }
+            )
+          }.to raise_error(/Unknown control options 'watermelons'/)
+        end
+
+        it 'should fail if not passed an Array of attributes to override' do
+          expect {
+            deferred_resources_type.new(
+              :name                         => 'foo',
+              :resource_type                => 'file',
+              :mode                         => 'enforcing',
+              :override_existing_attributes => {
+                'owner'   => nil,
+                'group'   => nil,
+                'content' => {
+                  'invalidates' => 'cheese'
+                }
+              },
+              :resources                    => {
+                '/tmp/test' => {
+                  'mode' => '0777'
+                }
+              }
+            )
+          }.to raise_error(/You must pass an Array of attributes to override for 'content'/)
+        end
       end
     end
 

--- a/spec/unit/puppet/type/deferred_resources_spec.rb
+++ b/spec/unit/puppet/type/deferred_resources_spec.rb
@@ -10,7 +10,7 @@ describe deferred_resources_type do
       it 'should fail if not passed' do
         expect{
           deferred_resources_type.new(
-            :name => 'foo',
+            :name      => 'foo',
             :resources => ['foo']
           )
         }.to raise_error(/must specify :resource_type/)
@@ -20,9 +20,9 @@ describe deferred_resources_type do
     context ':resources' do
       it 'should accept a Hash' do
         resource = deferred_resources_type.new(
-          :name => 'foo',
+          :name          => 'foo',
           :resource_type => 'package',
-          :resources => {'mypackage' => :undef}
+          :resources     => {'mypackage' => :undef}
         )
 
         expect(resource[:name]).to eq('foo')
@@ -35,9 +35,9 @@ describe deferred_resources_type do
 
       it 'should accept an Array' do
         resource = deferred_resources_type.new(
-          :name => 'foo',
+          :name          => 'foo',
           :resource_type => 'package',
-          :resources => ['mypackage','myotherpackage']
+          :resources     => ['mypackage','myotherpackage']
         )
 
         expect(resource[:resources]).to eq({
@@ -63,9 +63,9 @@ describe deferred_resources_type do
     context ':default_options' do
       it 'should accept vaild values' do
         resource = deferred_resources_type.new(
-          :name => 'foo',
-          :resource_type => 'package',
-          :resources => ['mypackage'],
+          :name            => 'foo',
+          :resource_type   => 'package',
+          :resources       => ['mypackage'],
           :default_options => { 'foo' => 'bar' }
         )
 
@@ -75,9 +75,9 @@ describe deferred_resources_type do
       it 'should fail on invalid values' do
         expect {
           deferred_resources_type.new(
-            :name => 'foo',
-            :resource_type => 'package',
-            :resources => ['mypackage'],
+            :name            => 'foo',
+            :resource_type   => 'package',
+            :resources       => ['mypackage'],
             :default_options => 'foo'
           )
         }.to raise_error(/xpecting a Hash/)
@@ -89,8 +89,8 @@ describe deferred_resources_type do
         resource = deferred_resources_type.new(
           :name => 'foo',
           :resource_type => 'package',
-          :resources => ['mypackage'],
-          :log_level => 'warning'
+          :resources     => ['mypackage'],
+          :log_level     => 'warning'
         )
 
         expect(resource[:log_level]).to eq(:warning)
@@ -102,8 +102,8 @@ describe deferred_resources_type do
         resource = deferred_resources_type.new(
           :name => 'foo',
           :resource_type => 'package',
-          :resources => ['mypackage'],
-          :mode => 'enforcing'
+          :resources     => ['mypackage'],
+          :mode          => 'enforcing'
         )
 
         expect(resource[:mode]).to eq(:enforcing)
@@ -121,10 +121,10 @@ describe deferred_resources_type do
     context 'when enforcing' do
       it 'should add the new resources to the catalog' do
         resource = deferred_resources_type.new(
-          :name => 'foo',
+          :name          => 'foo',
           :resource_type => 'package',
-          :resources => ['mypackage'],
-          :mode => 'enforcing'
+          :resources     => ['mypackage'],
+          :mode          => 'enforcing'
         )
 
         resource.autorequire
@@ -134,10 +134,10 @@ describe deferred_resources_type do
 
       it 'should skip matching existing resources' do
         resource = deferred_resources_type.new(
-          :name => 'foo',
+          :name          => 'foo',
           :resource_type => 'package',
-          :resources => ['mypackage'],
-          :mode => 'enforcing'
+          :resources     => ['mypackage'],
+          :mode          => 'enforcing'
         )
 
         @catalog.create_resource('Package', {'name' => 'mypackage'})
@@ -151,7 +151,7 @@ describe deferred_resources_type do
         resource = deferred_resources_type.new(
           :name => 'foo',
           :resource_type => 'package',
-          :resources => {
+          :resources     => {
             'mypackage' => {
               'ensure' => 'installed'
             }
@@ -165,15 +165,129 @@ describe deferred_resources_type do
 
         resource.autorequire
       end
+
+      context 'when overriding resources' do
+        before(:each) do
+          @resource = deferred_resources_type.new(
+            :name                         => 'foo',
+            :resource_type                => 'file',
+            :mode                         => 'enforcing',
+            :override_existing_attributes => [ 'owner', 'group', 'content' ],
+            :resources                    => {
+              '/tmp/test' => {
+                'ensure'  => 'file',
+                'owner'   => 'bob',
+                'group'   => 'alice',
+                'content' => 'Some stuff',
+                # This should be ignored
+                'mode'    => '0777'
+              }
+            }
+          )
+
+          @catalog.create_resource('File', {
+            'name'    => '/tmp/test',
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'content' => 'Test',
+            'mode'    => '0644'
+          })
+        end
+
+        it 'should override attributes in an existing catalog resource' do
+          @resource.autorequire
+
+          result = @catalog.resource('File[/tmp/test]')
+
+          expect(result[:owner]).to eq('bob')
+          expect(result[:group]).to eq('alice')
+          expect(result.parameter(:content).actual_content).to eq('Some stuff')
+          expect(result[:mode]).to eq('644')
+        end
+
+        it 'should not affect unrelated resources' do
+          @catalog.create_resource('File', {
+            'name'    => '/tmp/test2',
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'content' => 'Test',
+            'mode'    => '0644'
+          })
+
+          @resource.autorequire
+
+          result = @catalog.resource('File[/tmp/test]')
+
+          expect(result[:owner]).to eq('bob')
+          expect(result[:group]).to eq('alice')
+          expect(result.parameter(:content).actual_content).to eq('Some stuff')
+          expect(result[:mode]).to eq('644')
+
+          pristine_result = @catalog.resource('File[/tmp/test2]')
+
+          expect(pristine_result[:owner]).to eq('root')
+          expect(pristine_result[:group]).to eq('root')
+          expect(pristine_result.parameter(:content).actual_content).to eq('Test')
+          expect(pristine_result[:mode]).to eq('644')
+        end
+      end
+
+      context 'when overriding and invalidating attributes' do
+        it 'should override attributes in an existing catalog resource and invalidate "source"' do
+          @resource = deferred_resources_type.new(
+            :name                         => 'foo',
+            :resource_type                => 'file',
+            :mode                         => 'enforcing',
+            :override_existing_attributes => {
+              'owner'   => nil,
+              'group'   => nil,
+              'content' => {
+                'invalidates' => ['source']
+              }
+            },
+            :resources                    => {
+              '/tmp/test' => {
+                'ensure'  => 'file',
+                'owner'   => 'bob',
+                'group'   => 'alice',
+                'content' => 'Some stuff',
+                # This should be ignored
+                'mode'    => '0777'
+              }
+            }
+          )
+
+          @catalog.create_resource('File', {
+            'name'    => '/tmp/test',
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'source' => 'puppet:///my.server/test',
+            'mode'    => '0644'
+          })
+
+          @resource.autorequire
+
+          result = @catalog.resource('File[/tmp/test]')
+
+          expect(result[:owner]).to eq('bob')
+          expect(result[:group]).to eq('alice')
+          expect(result.parameter(:content).actual_content).to eq('Some stuff')
+          expect(result[:mode]).to eq('644')
+          expect(result[:source]).to be_nil
+        end
+      end
     end
 
     context 'when warning' do
       it 'should not add the new resources to the catalog' do
         resource = deferred_resources_type.new(
-          :name => 'foo',
-          :resource_type => 'package',
-          :resources => ['mypackage'],
-          :mode => 'warning',
+          :name            => 'foo',
+          :resource_type   => 'package',
+          :resources       => ['mypackage'],
+          :mode            => 'warning',
           :default_options => { 'ensure' => 'absent' }
         )
 
@@ -182,6 +296,52 @@ describe deferred_resources_type do
         resource.autorequire
 
         expect(@catalog.resource('Package', 'mypackage')).to be_nil
+      end
+
+      it 'should not override any existing resources' do
+          @resource = deferred_resources_type.new(
+            :name                         => 'foo',
+            :resource_type                => 'file',
+            :mode                         => 'warning',
+            :override_existing_attributes => {
+              'owner'   => nil,
+              'group'   => nil,
+              'content' => {
+                'invalidates' => ['source']
+              }
+            },
+            :resources                    => {
+              '/tmp/test' => {
+                'ensure'  => 'file',
+                'owner'   => 'bob',
+                'group'   => 'alice',
+                'content' => 'Some stuff',
+                # This should be ignored
+                'mode'    => '0777'
+              }
+            }
+          )
+
+          @catalog.create_resource('File', {
+            'name'    => '/tmp/test',
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'source' => 'puppet:///my.server/test',
+            'mode'    => '0644'
+          })
+
+          Puppet.expects(:send).with(:warning, %{deferred_resources: Would have overridden attributes 'owner', 'group', 'content' on existing resource File[/tmp/test]}).once
+
+          @resource.autorequire
+
+          result = @catalog.resource('File[/tmp/test]')
+
+          expect(result[:owner]).to eq('root')
+          expect(result[:group]).to eq('root')
+          expect(result[:source]).to eq(['puppet:///my.server/test'])
+          expect(result[:content]).to be_nil
+          expect(result[:mode]).to eq('644')
       end
     end
   end


### PR DESCRIPTION
* Add deferred_resources::files
* Add `override_existing_attributes` capability to the
  `deferred_resources` native type to allow file attributes to be
  overridden with more useful messages than what you get with resource
  collectors

SIMP-6106 #close