### PR TITLE
(SIMP-6892) Remove packages using absent or purged

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Thu Jul 25 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.2.3
+* Thu Jul 25 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.2.2
 - Allow users to set 'absent' or 'purged' when removing packages.
 
 * Tue Jul 23 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.2.2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Jul 25 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.2.3
+- Allow users to set 'absent' or 'purged' when removing packages.
+
 * Tue Jul 23 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.2.2
 - Remove unnecessary ``data_provider`` key in the metadata.json file.
 

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -12,6 +12,12 @@
 #   * A `Hash` can be used to add extra attributes for the package, but the
 #     `ensure` attribute will be overwritten if it is included.
 #
+# @param remove_ensure
+#   If removing, then this is the state that the packages should have.
+#
+#   * This will be overridden by anything set in options applied to an entry in
+#     the `$remove` Hash.
+#
 # @param install
 #   A list of packages to install.
 #
@@ -39,6 +45,7 @@
 #
 class deferred_resources::packages (
   Variant[Hash, Array]                 $remove          = {},
+  Enum['absent','purged']              $remove_ensure   = 'absent',
   Variant[Hash, Array]                 $install         = {},
   Enum['latest','present','installed'] $install_ensure  = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
   Hash                                 $default_options = {},
@@ -51,7 +58,7 @@ class deferred_resources::packages (
     deferred_resources{ "${module_name} Package remove":
       resources       => $remove,
       resource_type   => 'package',
-      default_options => $default_options + { 'ensure' => 'absent' },
+      default_options => $default_options + { 'ensure' => $remove_ensure },
       mode            => $mode,
       log_level       => $log_level
     }

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -33,6 +33,7 @@ describe 'deferred_resources::packages' do
         context "with parameters set" do
           let(:params) {{
             'remove'         => package_array,
+            'remove_ensure'  => 'purged',
             'install'        => package_hash,
             'install_ensure' => 'present',
             'mode'           => 'enforcing',
@@ -53,7 +54,7 @@ describe 'deferred_resources::packages' do
             'resource_type'   => 'package',
             'resources'       => params['remove'],
             'mode'            => params['mode'],
-            'default_options' => { 'ensure' => 'absent' },
+            'default_options' => { 'ensure' => params['remove_ensure'] },
             'log_level'       => params['log_level']
           })}
 


### PR DESCRIPTION
Allow users to set `absent` or `purged` when removing packages.

This works around a bug in the Puppet `package` provider on EL systems
where `yum` is only used if you call `purged`

SIMP-6892 #close