### PR TITLE
(SIMP-8839) Remove EL6 from pupmod-simp-deferred_resources

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 *.erb eol=lf
 *.pp eol=lf
 *.sh eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-# NOTE: This file is managed by puppetsync.  Make sure any changes are
-#       reflected in the control repo.
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 .*.sw?
 .yardoc
 .idea/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,10 @@
 # ------------------------------------------------------------------------------
 #             NOTICE: **This file is maintained with puppetsync**
 #
-# Everything above the "Repo-specific content" comment will be overwritten by
-# the next puppetsync.
+# This file is updated automatically as part of a puppet module baseline.
+#
+# The next baseline sync will overwrite any local changes to everything above
+# the line "# Repo-specific content"
 # ------------------------------------------------------------------------------
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 #
@@ -13,11 +15,10 @@
 # Release       Puppet   Ruby    EOL
 # SIMP 6.4      5.5      2.4.10  TBD
 # PE 2018.1     5.5      2.4.10  2021-01 (LTS overlap)
-# PE 2019.8     6.16     2.5.7   2021-11 (LTS)
+# PE 2019.8     6.18     2.5.7   2022-12 (LTS)
 ---
 
 stages:
-  - 'sanity'
   - 'validation'
   - 'acceptance'
   - 'compliance'
@@ -76,6 +77,9 @@ variables:
     - "{manifests,files,types}/**/*"
     - "templates/*.{erb,epp}"
     - "lib/**/*"
+    - "Gemfile"
+    - "SIMP/**/*"
+    - "data/**/*"
   exists:
     - "spec/{classes,unit,defines,type_aliases,types,hosts}/**/*_spec.rb"
 
@@ -87,6 +91,9 @@ variables:
     - "{manifests,files,types}/**/*"
     - "templates/*.{erb,epp}"
     - "lib/**/*"
+    - "Gemfile"
+    - "SIMP/**/*"
+    - "data/**/*"
   exists:
     - "spec/acceptance/**/*_spec.rb"
 
@@ -208,10 +215,10 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
-.pup_6_16_0: &pup_6_16_0
+.pup_6_18_0: &pup_6_18_0
   image: 'ruby:2.5'
   variables:
-    PUPPET_VERSION: '6.16.0'
+    PUPPET_VERSION: '6.18.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
@@ -251,14 +258,13 @@ variables:
 # Pipeline / testing matrix
 #=======================================================================
 
-sanity_checks:
+releng_checks:
   <<: *pup_5
   <<: *setup_bundler_env
-  stage: 'sanity'
+  stage: 'validation'
   tags: ['docker']
   script:
-    - 'if `hash apt-get`; then apt-get update; fi'
-    - 'if `hash apt-get`; then apt-get install -y rpm; fi'
+    - 'command -v rpm || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
     - 'bundle exec rake check:dot_underscore'
     - 'bundle exec rake check:test_file'
     - 'bundle exec rake pkg:check_version'
@@ -294,8 +300,8 @@ pup6-unit:
   <<: *unit_tests
   <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
-pup6.16.0-unit:
-  <<: *pup_6_16_0
+pup6.18.0-unit:
+  <<: *pup_6_18_0
   <<: *unit_tests
 
 # ------------------------------------------------------------------------------
@@ -357,33 +363,33 @@ pup6-fips-compliance:
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance,default]'
 
-pup6.16.0:
-  <<: *pup_6_16_0
+pup6.18.0:
+  <<: *pup_6_18_0
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,default]'
 
-pup6.16.0-fips:
-  <<: *pup_6_16_0
+pup6.18.0-fips:
+  <<: *pup_6_18_0
   <<: *acceptance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
 
-pup6.16.0-oel-combined-x64:
-  <<: *pup_6_16_0
+pup6.18.0-oel-combined-x64:
+  <<: *pup_6_18_0
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,oel-combined-x64]'
 
-pup6.16.0-oel-combined-x64-fips:
-  <<: *pup_6_16_0
+pup6.18.0-oel-combined-x64-fips:
+  <<: *pup_6_18_0
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel-combined-x64]'
 
-pup6.16.0-fips-compliance:
-  <<: *pup_6_16_0
+pup6.18.0-fips-compliance:
+  <<: *pup_6_18_0
   <<: *compliance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance,default]'

--- a/.pmtignore
+++ b/.pmtignore
@@ -1,8 +1,10 @@
 # .pmtignore is required to mask symlinks from the `puppet module build` test
 # In the module's pipeline sanity checks
 # ------------------------------------------------------------------------------
-# NOTE: This file is managed by puppetsync.  Make sure any changes are
-#       reflected in the control repo.
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
 # ------------------------------------------------------------------------------
 .*.sw?
 .yardoc

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
 --no-class_inherits_from_params_class-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Dec 17 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.3.1
+- Removed EL6 support
+
 * Wed Dec 11 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.3.0
 - Add EL8 support
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 gem_sources = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
 
 ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-deferred_resources",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "simp",
   "summary": "This module creates custom types used to add resources to the catalog after the compilation of the manifests",
   "license": "Apache-2.0",
@@ -24,7 +24,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -32,7 +31,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -40,7 +38,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]

--- a/spec/acceptance/nodesets/centos-combined-x64.yml
+++ b/spec/acceptance/nodesets/centos-combined-x64.yml
@@ -13,11 +13,6 @@ HOSTS:
     box:        centos/7
     hypervisor: vagrant
 
-  el6:
-    platform:   el-6-x86_64
-    box:        centos/6
-    hypervisor: vagrant
-
   el8:
     platform:   el-8-x86_64
     box:        centos/8

--- a/spec/acceptance/nodesets/oel-combined-x64.yml
+++ b/spec/acceptance/nodesets/oel-combined-x64.yml
@@ -13,11 +13,6 @@ HOSTS:
     box:        onyxpoint/oel-7-x86_64
     hypervisor: vagrant
 
-  oel6:
-    platform:   el-6-x86_64
-    box:        onyxpoint/oel-6-x86_64
-    hypervisor: vagrant
-
   oel8:
     platform:   el-8-x86_64
     box:        generic/oracle8


### PR DESCRIPTION
This patch removes EL6 as a supported OS in `metadata.json`, Hiera YAML
files and from the beaker acceptance tests and nodesets.

SIMP-8853 #close
[SIMP-8839] #comment Removed EL6 from pupmod-simp-deferred_resources
[SIMP-8489] #comment Updated pupmod-simp-deferred_resources GLCI pipeline to Puppet 6.18
[SIMP-8923] #comment Renamed 'sanity' to 'releng' in pupmod-simp-deferred_resources

[SIMP-8839]: https://simp-project.atlassian.net/browse/SIMP-8839
[SIMP-8489]: https://simp-project.atlassian.net/browse/SIMP-8489
[SIMP-8923]: https://simp-project.atlassian.net/browse/SIMP-8923