### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x'
-            puppet_version: '~> 7.21.0'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
+            puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
-            ruby_version: '3.2'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.5.0
+- Add RockyLinux 8 support
+
 * Sun Feb 13 2022 Trevor Vaughan <trevor@sicura.us> - 0.4.1
 - Support Amazon Linux 2
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -61,11 +61,11 @@ class deferred_resources::files (
 
   unless empty($remove) {
     deferred_resources{ "${module_name} File remove":
-      resources                    => $remove,
-      resource_type                => 'file',
-      default_options              => { 'ensure' => 'absent' },
-      mode                         => $mode,
-      log_level                    => $log_level
+      resources       => $remove,
+      resource_type   => 'file',
+      default_options => { 'ensure' => 'absent' },
+      mode            => $mode,
+      log_level       => $log_level
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-deferred_resources",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "author": "simp",
   "summary": "This module creates custom types used to add resources to the catalog after the compilation of the manifests",
   "license": "Apache-2.0",
@@ -17,7 +17,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -45,6 +45,12 @@
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
         "8"
       ]
     }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,7 +89,7 @@ RSpec.configure do |c|
   }
 
   c.mock_framework = :rspec
-  c.mock_with :mocha
+  c.mock_with :rspec
 
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')

--- a/spec/unit/puppet/type/deferred_resources_spec.rb
+++ b/spec/unit/puppet/type/deferred_resources_spec.rb
@@ -111,11 +111,12 @@ describe deferred_resources_type do
     end
   end
 
-  context 'when processing the catalog' do
-    before(:each) do
-      @catalog = Puppet::Resource::Catalog.new
 
-      Puppet::Type::Deferred_resources.any_instance.stubs(:catalog).returns(@catalog)
+  context 'when processing the catalog' do
+    let(:catalog){ Puppet::Resource::Catalog.new }
+    before do
+      @catalog = Puppet::Resource::Catalog.new
+      allow_any_instance_of(Puppet::Type::Deferred_resources).to receive(:catalog).and_return(@catalog)
     end
 
     context 'when enforcing' do
@@ -142,7 +143,7 @@ describe deferred_resources_type do
 
         @catalog.create_resource('Package', {'name' => 'mypackage'})
 
-        Puppet.expects(:debug).with('deferred_resources: Ignoring existing resource Package[mypackage]').once
+        expect(Puppet).to receive(:debug).with('deferred_resources: Ignoring existing resource Package[mypackage]').once
 
         resource.autorequire
       end
@@ -161,7 +162,7 @@ describe deferred_resources_type do
 
         @catalog.create_resource('Package', {'name' => 'mypackage', 'ensure' => 'absent'})
 
-        Puppet.expects(:send).with(:warning, "deferred_resources: Existing resource 'Package[mypackage]' at ':' has options that differ from deferred_resources::<x> parameters").once
+        expect(Puppet).to receive(:send).with(:warning, "deferred_resources: Existing resource 'Package[mypackage]' at ':' has options that differ from deferred_resources::<x> parameters").once
 
         resource.autorequire
       end
@@ -378,7 +379,7 @@ describe deferred_resources_type do
           :default_options => { 'ensure' => 'absent' }
         )
 
-        Puppet.expects(:send).with(:warning, 'deferred_resources: Would have created Package[mypackage] with {:ensure=>"absent"}').once
+        expect(Puppet).to receive(:send).with(:warning, 'deferred_resources: Would have created Package[mypackage] with {:ensure=>"absent"}').once
 
         resource.autorequire
 
@@ -418,7 +419,7 @@ describe deferred_resources_type do
             'mode'    => '0644'
           })
 
-          Puppet.expects(:send).with(:warning, %{deferred_resources: Would have overridden attributes 'owner', 'group', 'content' on existing resource File[/tmp/test]}).once
+          expect(Puppet).to receive(:send).with(:warning, %{deferred_resources: Would have overridden attributes 'owner', 'group', 'content' on existing resource File[/tmp/test]}).once
 
           @resource.autorequire
 


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.